### PR TITLE
fix(weather): remove unnecessary DOMAIN constant and update fetch URL

### DIFF
--- a/src/app/weather/hooks/useCity.ts
+++ b/src/app/weather/hooks/useCity.ts
@@ -1,12 +1,11 @@
 "use client";
 import useSWR from "swr";
 import { CityResponseType } from "../types";
-import { DOMAIN } from "@/app/api/const";
 
 export default function useCity(query: string) {
 	const { data, error, isLoading } = useSWR<CityResponseType, Error>(
 		query !== "" ? ["api/city", query] : null,
-		([url, query]) => fetch(`${DOMAIN}${url}?q=${query}`).then((res) => res.json()),
+		([url, query]) => fetch(`${url}?q=${query}`).then((res) => res.json()),
 		{
 			revalidateIfStale: false,
 			revalidateOnFocus: false,


### PR DESCRIPTION
## 此次改動的目的

remove specific domain in api route to make the endpoint work correctly after deployed.

## 實作方法

- [b01fe42](https://github.com/Maki0419-git/miyu-website/pull/1/commits/b01fe4267f93a71a3098b35afef662b927924e56): just use api pathname instead of full url .

## 專案相關資料
📅 日期 : 
🗒️ clickup : 
🧑‍🎨 figma:
📓 others:

## 我有遵守：
- [x] 大家所訂定的 [Git comment 格式](https://app.clickup.com/5719919/docs/5ehvf-1720)
- [x] 每個 commit 不超過 200 行變動
- [x] 每個  PR 不超過 500 行變動