### PR TITLE
fix(weather): set timezone for dayjs

### DIFF
--- a/src/app/weather/components/server/CurrentWeather.tsx
+++ b/src/app/weather/components/server/CurrentWeather.tsx
@@ -1,10 +1,10 @@
 import { styled } from "@pigment-css/react";
-import dayjs from "dayjs";
 import { WEATHER_DETAIL } from "../../constant";
 import { getWeatherType } from "../../utils/getWeatherType";
 import { WEATHER_ICON } from "./WeatherIcon";
 import Thermometer from "../../../../assets/weather/thermometer.svg";
 import { getCurrentWeather } from "../../action";
+import dayjs from "../../utils/dayjs";
 
 const Container = styled("div")({
 	flex: 3,

--- a/src/app/weather/components/server/CurrentWeather.tsx
+++ b/src/app/weather/components/server/CurrentWeather.tsx
@@ -53,6 +53,7 @@ export async function CurrentWeather({ isDayOrNight, city }: CurrentWeatherProps
 		GeoInfo: { CountyName: countyName },
 		StationName: station,
 	} = targetStation;
+	console.log({ currentWeatherDateTime: dateTime });
 	const time = dayjs(dateTime).format("hh:mm A");
 	const { Weather: weather, AirTemperature: temperature } = targetStation.WeatherElement;
 	const weatherIcon = WEATHER_ICON[isDayOrNight][getWeatherType(WEATHER_DETAIL, weather)];

--- a/src/app/weather/page.tsx
+++ b/src/app/weather/page.tsx
@@ -4,9 +4,9 @@ import { getWeatherApiEndpoint } from "./utils/getWeatherApiEndpoint";
 import errorHandler from "@/utils/errorHandler";
 import { WeatherAPIResponse } from "./types";
 import { getIsDayOrNight } from "./utils/getIsDayOrNight";
-import dayjs from "dayjs";
 import { BottomSection } from "./components/client";
 import { CurrentWeather, ThirtySixHoursWeather } from "./components/server";
+import dayjs from "./utils/dayjs";
 const TopSection = styled("div")({
 	display: "flex",
 	width: "100%",

--- a/src/app/weather/utils/dayjs.ts
+++ b/src/app/weather/utils/dayjs.ts
@@ -1,0 +1,9 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.tz.setDefault("Asia/Taipei");
+
+export default dayjs.tz;

--- a/src/app/weather/utils/dayjs.ts
+++ b/src/app/weather/utils/dayjs.ts
@@ -4,6 +4,9 @@ import timezone from "dayjs/plugin/timezone";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
-dayjs.tz.setDefault("Asia/Taipei");
 
-export default dayjs.tz;
+function setTimeZoneToTaipei(date?: string) {
+	return dayjs(date).tz("Asia/Taipei");
+}
+
+export default setTimeZoneToTaipei;

--- a/src/app/weather/utils/getIsDayOrNight.ts
+++ b/src/app/weather/utils/getIsDayOrNight.ts
@@ -1,13 +1,12 @@
-import dayjs from "dayjs";
 import { SunriseSunsetTime } from "../types";
+import dayjs from "./dayjs";
 
 export function getIsDayOrNight(time: SunriseSunsetTime): "day" | "night" {
-  const { Date: date, SunRiseTime: sunriseTime, SunSetTime: sunsetTime } = time;
-  const nowInMilliseconds = dayjs().valueOf();
-  const sunriseTimeInMilliseconds = dayjs(`${date} ${sunriseTime}`).valueOf();
-  const sunsetTimeInMilliseconds = dayjs(`${date} ${sunsetTime}`).valueOf();
-  return nowInMilliseconds >= sunriseTimeInMilliseconds &&
-    nowInMilliseconds <= sunsetTimeInMilliseconds
-    ? "day"
-    : "night";
+	const { Date: date, SunRiseTime: sunriseTime, SunSetTime: sunsetTime } = time;
+	const nowInMilliseconds = dayjs().valueOf();
+	const sunriseTimeInMilliseconds = dayjs(`${date} ${sunriseTime}`).valueOf();
+	const sunsetTimeInMilliseconds = dayjs(`${date} ${sunsetTime}`).valueOf();
+	return nowInMilliseconds >= sunriseTimeInMilliseconds && nowInMilliseconds <= sunsetTimeInMilliseconds
+		? "day"
+		: "night";
 }


### PR DESCRIPTION
## Proposed Change

display correctly time in UTC+8

## Solution

- [d902823](https://github.com/Maki0419-git/miyu-website/pull/4/commits/d90282331125f07d7dc6273daad5452a623fa5d0): Because dayjs will convert the time to the local time of where dayjs executed, and it will be where the server is located because the component which needs it is in RSC. So, we need to set the timezone to taipei to show the time correctly. 

## Related Info
📅 日期 : 

🗒️ clickup :

🧑‍🎨 figma:

🐾 issue: 

📓 others: https://day.js.org/docs/en/timezone/converting-to-zone

## I am abided to...：
- [x] 大家所訂定的 [Git comment 格式](https://app.clickup.com/5719919/docs/5ehvf-1720)
- [x] 每個 commit 不超過 200 行變動
- [x] 每個  PR 不超過 500 行變動
