### PR TITLE
refactor(weather): parse time in client side

### DIFF
--- a/src/app/weather/components/client/CurrentWeatherTime.tsx
+++ b/src/app/weather/components/client/CurrentWeatherTime.tsx
@@ -1,0 +1,8 @@
+"use client";
+import dayjs from "dayjs";
+
+export function CurrentWeatherTime({ dateTime }: { dateTime: string }) {
+	const time = dayjs(dateTime).format("hh:mm A");
+
+	return <h2>{time}</h2>;
+}

--- a/src/app/weather/components/client/WeatherCardTime.tsx
+++ b/src/app/weather/components/client/WeatherCardTime.tsx
@@ -1,0 +1,43 @@
+"use client";
+import dayjs from "dayjs";
+import { isPast } from "../../utils/isPast";
+import { styled } from "@pigment-css/react";
+import { isTomorrow } from "../../utils/isTomorrow";
+
+const Ribbon = styled("div")({
+	"&:before": {
+		position: "absolute",
+		content: '""',
+		width: 0,
+		height: 0,
+		top: "24px",
+		left: "-18px",
+		borderTop: "16px solid transparent",
+		borderBottom: "16px solid transparent",
+		borderRight: "16px solid #3949ab",
+	},
+	"&:after": {
+		position: "absolute",
+		content: '"明天"',
+		top: "0.6rem",
+		left: "-1.2rem",
+		padding: "0.3rem 0rem",
+		width: "5rem",
+		background: "#3949ab",
+		color: "white",
+		textAlign: "center",
+		fontFamily: "Roboto, sans-serif",
+		boxShadow: "4px 4px 15px rgba(26, 35, 126, 0.2)",
+	},
+});
+
+export function WeatherCardTime({ dateTime }: { dateTime: string }) {
+	const time = dayjs(dateTime).format("hh:mm A");
+
+	return (
+		<>
+			{isTomorrow(dayjs(dateTime)) && <Ribbon />}
+			<h3>{isPast(dayjs(dateTime)) ? "Now" : time}</h3>
+		</>
+	);
+}

--- a/src/app/weather/components/client/index.ts
+++ b/src/app/weather/components/client/index.ts
@@ -1,2 +1,3 @@
 export * from "./bottomSection";
 export * from "./CurrentWeatherTime";
+export * from "./WeatherCardTime";

--- a/src/app/weather/components/client/index.ts
+++ b/src/app/weather/components/client/index.ts
@@ -1,1 +1,2 @@
 export * from "./bottomSection";
+export * from "./CurrentWeatherTime";

--- a/src/app/weather/components/server/CurrentWeather.tsx
+++ b/src/app/weather/components/server/CurrentWeather.tsx
@@ -4,7 +4,7 @@ import { getWeatherType } from "../../utils/getWeatherType";
 import { WEATHER_ICON } from "./WeatherIcon";
 import Thermometer from "../../../../assets/weather/thermometer.svg";
 import { getCurrentWeather } from "../../action";
-import dayjs from "../../utils/dayjs";
+import { CurrentWeatherTime } from "../client";
 
 const Container = styled("div")({
 	flex: 3,
@@ -54,7 +54,6 @@ export async function CurrentWeather({ isDayOrNight, city }: CurrentWeatherProps
 		StationName: station,
 	} = targetStation;
 	console.log({ currentWeatherDateTime: dateTime });
-	const time = dayjs(dateTime).format("hh:mm A");
 	const { Weather: weather, AirTemperature: temperature } = targetStation.WeatherElement;
 	const weatherIcon = WEATHER_ICON[isDayOrNight][getWeatherType(WEATHER_DETAIL, weather)];
 
@@ -63,7 +62,7 @@ export async function CurrentWeather({ isDayOrNight, city }: CurrentWeatherProps
 	return (
 		<Container>
 			<h1>{countyName}</h1>
-			<h2>{time}</h2>
+			<CurrentWeatherTime dateTime={dateTime} />
 			<WeatherInfo>
 				<Temperature>
 					<Thermometer width={100} height={100} />

--- a/src/app/weather/components/server/ThirtySixHoursWeather.tsx
+++ b/src/app/weather/components/server/ThirtySixHoursWeather.tsx
@@ -1,11 +1,10 @@
 import errorHandler from "@/utils/errorHandler";
 import { getWeatherApiEndpoint } from "../../utils/getWeatherApiEndpoint";
-import { css, styled } from "@pigment-css/react";
+import { styled } from "@pigment-css/react";
 import { WeatherAPIResponse } from "../../types";
 import Humidity from "../../../../assets/weather/humidity.svg";
 import createWeatherCardList from "../../utils/createWeatherCardList";
-import { isTomorrow } from "../../utils/isTomorrow";
-import { isPast } from "../../utils/isPast";
+import { WeatherCardTime } from "../client";
 
 const Container = styled("div")({
 	flex: 7,
@@ -17,9 +16,6 @@ const Container = styled("div")({
 		textShadow: "2px 2px 4px rgba(0, 0, 0, 0.5)",
 		margin: "10px 20px",
 	},
-	// "@media (max-width: 1440px)": {
-	// 	alignItems: "flex-start",
-	// },
 });
 
 const WeatherCardContainer = styled("div")({
@@ -30,33 +26,6 @@ const WeatherCardContainer = styled("div")({
 	height: "70%",
 	"@media (max-width: 1440px)": {
 		height: "80%",
-	},
-});
-
-const cardRibbonStyles = css({
-	"&:before": {
-		position: "absolute",
-		content: '""',
-		width: 0,
-		height: 0,
-		top: "24px",
-		left: "-18px",
-		borderTop: "16px solid transparent",
-		borderBottom: "16px solid transparent",
-		borderRight: "16px solid #3949ab",
-	},
-	"&:after": {
-		position: "absolute",
-		content: '"明天"',
-		top: "0.6rem",
-		left: "-1.2rem",
-		padding: "0.3rem 0rem",
-		width: "5rem",
-		background: "#3949ab",
-		color: "white",
-		textAlign: "center",
-		fontFamily: "Roboto, sans-serif",
-		boxShadow: "4px 4px 15px rgba(26, 35, 126, 0.2)",
 	},
 });
 
@@ -144,8 +113,8 @@ export async function ThirtySixHoursWeather({ isDayOrNight, city }: ThirtySixHou
 		<Container>
 			<WeatherCardContainer>
 				{weatherCardList.map((weatherCard, index) => (
-					<WeatherCard key={index} className={isTomorrow(weatherCard.startTime) ? cardRibbonStyles : ""}>
-						<h3>{isPast(weatherCard.startTime) ? "Now" : weatherCard.startTime.format("hh:mm A")}</h3>
+					<WeatherCard key={index}>
+						<WeatherCardTime dateTime={weatherCard.startTime} />
 						{weatherCard.weatherElement.Wx.img}
 						<h4>{weatherCard.weatherElement.Wx.description}</h4>
 						<MinMaxTemperature>

--- a/src/app/weather/utils/createWeatherCardList.ts
+++ b/src/app/weather/utils/createWeatherCardList.ts
@@ -1,12 +1,10 @@
-import { Dayjs } from "dayjs";
-import dayjs from "../utils/dayjs";
 import { WeatherElement } from "../types";
 import { WEATHER_ICON } from "../components/server/WeatherIcon";
 import { getWeatherType } from "./getWeatherType";
 import { WEATHER_CODE } from "../constant";
 
 type WeatherCardType = {
-	startTime: Dayjs;
+	startTime: string;
 	weatherElement: {
 		Wx: {
 			description: string;
@@ -29,7 +27,7 @@ export default function createWeatherCardList(
 		time.forEach((time, index) => {
 			if (!acc[index])
 				acc[index] = {
-					startTime: dayjs(time.startTime),
+					startTime: time.startTime,
 					weatherElement: {},
 				} as WeatherCardType;
 			switch (elementName) {


### PR DESCRIPTION
## Proposed Change

instead of setting timezone in app, rendering time in client side will be better

## Solution

make the component related to **dayjs** be client component 

## Related Info
📅 日期 : 

🗒️ clickup :

🧑‍🎨 figma:

🐾 issue: 

📓 others:

## I am abided to...：
- [x] 大家所訂定的 [Git comment 格式](https://app.clickup.com/5719919/docs/5ehvf-1720)
- [x] 每個 commit 不超過 200 行變動
- [x] 每個  PR 不超過 500 行變動
