### PR TITLE
fix(weather): make WeatherImage as RSC

### DIFF
--- a/src/app/weather/action.ts
+++ b/src/app/weather/action.ts
@@ -26,24 +26,3 @@ export async function getCurrentWeather(cityName: string[]): Promise<WeatherAPIR
 		throw error;
 	}
 }
-
-export async function getSunriseSunsetTime(
-	city: string,
-	date: string,
-): Promise<WeatherAPIResponse<"SUNRISE_SUNSET_TIME">> {
-	try {
-		const endpoint = getWeatherApiEndpoint("SUNRISE_SUNSET_TIME");
-		const response = await fetch(
-			`${endpoint}?CountyName=${city}&Date=${date}&Authorization=${process.env.WEATHER_API_KEY}`,
-		);
-		if (!response.ok) {
-			errorHandler("SUNRISE_SUNSET_TIME", response.status);
-		}
-
-		const data = await response.json();
-		return data;
-	} catch (error: any) {
-		console.log({ error });
-		throw error;
-	}
-}

--- a/src/app/weather/components/client/CurrentWeatherTime.tsx
+++ b/src/app/weather/components/client/CurrentWeatherTime.tsx
@@ -1,8 +1,9 @@
-"use client";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+dayjs.extend(utc);
 
 export function CurrentWeatherTime({ dateTime }: { dateTime: string }) {
-	const time = dayjs(dateTime).format("hh:mm A");
+	const time = dayjs(dateTime).utcOffset(8).format("hh:mm A");
 
 	return <h2>{time}</h2>;
 }

--- a/src/app/weather/components/client/WeatherImage.tsx
+++ b/src/app/weather/components/client/WeatherImage.tsx
@@ -1,12 +1,12 @@
 import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
 import { WeatherAPIResponse, WeatherType } from "../../types";
 import { WEATHER_ICON } from "../server/WeatherIcon";
 import { getIsDayOrNight } from "../../utils/getIsDayOrNight";
 import { getWeatherApiEndpoint } from "../../utils/getWeatherApiEndpoint";
 import errorHandler from "@/utils/errorHandler";
 
-dayjs.extend(utc);
+dayjs.extend(timezone);
 
 async function getSunriseSunsetTime(city: string, date: string): Promise<WeatherAPIResponse<"SUNRISE_SUNSET_TIME">> {
 	try {
@@ -35,7 +35,8 @@ export async function WeatherImage({
 	city: string;
 	targetTime: string;
 }) {
-	const day = dayjs(targetTime).utcOffset(8).format("YYYY-MM-DD");
+	const dayRemoveUTCOffset = targetTime.replace(/\+\d{2}:\d{2}$/, "");
+	const day = dayjs.tz(dayRemoveUTCOffset, "Asia/Taipei").format("YYYY-MM-DD");
 	const data = await getSunriseSunsetTime(city, day);
 	const sunriseSunsetTime = data.records.locations.location[0].time[0];
 	const isDayOrNight = getIsDayOrNight(dayjs(targetTime), sunriseSunsetTime);

--- a/src/app/weather/components/client/WeatherImage.tsx
+++ b/src/app/weather/components/client/WeatherImage.tsx
@@ -36,10 +36,11 @@ export async function WeatherImage({
 	targetTime: string;
 }) {
 	const dayRemoveUTCOffset = targetTime.replace(/\+\d{2}:\d{2}$/, "");
-	const day = dayjs.tz(dayRemoveUTCOffset, "Asia/Taipei").format("YYYY-MM-DD");
-	const data = await getSunriseSunsetTime(city, day);
+	const day = dayjs.tz(dayRemoveUTCOffset, "Asia/Taipei");
+	const date = day.format("YYYY-MM-DD");
+	const data = await getSunriseSunsetTime(city, date);
 	const sunriseSunsetTime = data.records.locations.location[0].time[0];
-	const isDayOrNight = getIsDayOrNight(dayjs(targetTime), sunriseSunsetTime);
+	const isDayOrNight = getIsDayOrNight(day, sunriseSunsetTime);
 	const weatherIcon = WEATHER_ICON[isDayOrNight][weather];
 
 	return weatherIcon;

--- a/src/app/weather/components/client/WeatherImage.tsx
+++ b/src/app/weather/components/client/WeatherImage.tsx
@@ -40,7 +40,7 @@ export async function WeatherImage({
 	const date = day.format("YYYY-MM-DD");
 	const data = await getSunriseSunsetTime(city, date);
 	const sunriseSunsetTime = data.records.locations.location[0].time[0];
-	const isDayOrNight = getIsDayOrNight(day, sunriseSunsetTime);
+	const isDayOrNight = getIsDayOrNight(dayjs(targetTime), sunriseSunsetTime);
 	const weatherIcon = WEATHER_ICON[isDayOrNight][weather];
 
 	return weatherIcon;

--- a/src/app/weather/components/client/WeatherImage.tsx
+++ b/src/app/weather/components/client/WeatherImage.tsx
@@ -35,8 +35,7 @@ export async function WeatherImage({
 	city: string;
 	targetTime: string;
 }) {
-	const dayRemoveUTCOffset = targetTime.replace(/\+\d{2}:\d{2}$/, "");
-	const day = dayjs.tz(dayRemoveUTCOffset, "Asia/Taipei");
+	const day = dayjs(targetTime).tz("Asia/Taipei");
 	const date = day.format("YYYY-MM-DD");
 	const data = await getSunriseSunsetTime(city, date);
 	const sunriseSunsetTime = data.records.locations.location[0].time[0];

--- a/src/app/weather/components/client/WeatherImage.tsx
+++ b/src/app/weather/components/client/WeatherImage.tsx
@@ -1,27 +1,30 @@
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
-import { WeatherType } from "../../types";
+import { WeatherAPIResponse, WeatherType } from "../../types";
 import { WEATHER_ICON } from "../server/WeatherIcon";
 import { getIsDayOrNight } from "../../utils/getIsDayOrNight";
-import { getSunriseSunsetTime } from "../../action";
-import { keyframes, styled } from "@pigment-css/react";
+import { getWeatherApiEndpoint } from "../../utils/getWeatherApiEndpoint";
+import errorHandler from "@/utils/errorHandler";
 
 dayjs.extend(utc);
 
-const pulse = keyframes({
-	"0%": { backgroundColor: "rgba(238, 238, 238, 0.3)" },
-	"50%": { backgroundColor: "rgba(245, 245, 245, 0.3)" },
-	"100%": { backgroundColor: "rgba(238, 238, 238, 0.3)" },
-});
+async function getSunriseSunsetTime(city: string, date: string): Promise<WeatherAPIResponse<"SUNRISE_SUNSET_TIME">> {
+	try {
+		const endpoint = getWeatherApiEndpoint("SUNRISE_SUNSET_TIME");
+		const response = await fetch(
+			`${endpoint}?CountyName=${city}&Date=${date}&Authorization=${process.env.WEATHER_API_KEY}`,
+		);
+		if (!response.ok) {
+			errorHandler("SUNRISE_SUNSET_TIME", response.status);
+		}
 
-const Skeleton = styled("div")({
-	backgroundColor: "rgba(238, 238, 238, 0.3)",
-	animation: `${pulse} 0.2s infinite ease-in-out`,
-	width: "80px",
-	height: "80px",
-	margin: "15px",
-	borderRadius: "8px",
-});
+		const data = await response.json();
+		return data;
+	} catch (error: any) {
+		console.log({ error });
+		throw error;
+	}
+}
 
 export async function WeatherImage({
 	weather,


### PR DESCRIPTION
## Proposed Change

Get sunrise sunset time in server instead of client because we can use `obsTime` that return from `getCurrentWeather` or `startTime` from  `getThirtySixHoursWeather()` to fetch one more time to get the data we want. ( we can not get sunrise sunset time by dayjs() in page.tsx because the dayjs() will return the time in timezone that server in , and it may be the wrong day. )

## Solution

make `WeatherImage` as RSC, and getSunriseSunsetTime depend on day. ( We should use `dayjs.tz(dayRemoveUTCOffset, "Asia/Taipei")` to ensure the time return from format is the timezone in taipei )



## Related Info
📅 日期 : 

🗒️ clickup :

🧑‍🎨 figma:

🐾 issue: 

📓 others:

## I am abided to...：
- [x] 大家所訂定的 [Git comment 格式](https://app.clickup.com/5719919/docs/5ehvf-1720)
- [x] 每個 commit 不超過 200 行變動
- [x] 每個  PR 不超過 500 行變動
