### PR TITLE
fix(github-workflow): only release when deployment_status is success

### DIFF
--- a/.github/workflows/release_on_deployment.yaml
+++ b/.github/workflows/release_on_deployment.yaml
@@ -4,6 +4,7 @@ on:
   deployment_status:
     branches:
       - main
+    types: [success]
 
 jobs:
   release:


### PR DESCRIPTION
## Proposed Change

only release when deployment_status is success

## Solution

as above

## Related Info
📅 日期 : 

🗒️ clickup :

🧑‍🎨 figma:

🐾 issue: 

📓 others:

## I am abided to...：
- [x] 大家所訂定的 [Git comment 格式](https://app.clickup.com/5719919/docs/5ehvf-1720)
- [x] 每個 commit 不超過 200 行變動
- [x] 每個  PR 不超過 500 行變動
