### PR TITLE
Refactor/weather/use next image instead of background image

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,68 +1,72 @@
-import { withPigment } from "@pigment-css/nextjs-plugin";
-import { withSentryConfig } from "@sentry/nextjs";
+import { withPigment } from "@pigment-css/nextjs-plugin"
+import { withSentryConfig } from "@sentry/nextjs"
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "picsum.photos",
-      },
-    ],
-  },
-  webpack(config) {
-    config.module.rules.push({
-      test: /\.svg$/i,
-      // issuer: /\.[jt]sx?$/,
-      use: ["@svgr/webpack"],
-    });
+	images: {
+		remotePatterns: [
+			{
+				protocol: "https",
+				hostname: "picsum.photos",
+			},
+			{
+				protocol: "https",
+				hostname: "images.unsplash.com",
+			},
+		],
+	},
+	webpack(config) {
+		config.module.rules.push({
+			test: /\.svg$/i,
+			// issuer: /\.[jt]sx?$/,
+			use: ["@svgr/webpack"],
+		})
 
-    return config;
-  },
-};
+		return config
+	},
+}
 
 const config = withPigment(
-  withSentryConfig(
-    nextConfig,
-    {
-      // For all available options, see:
-      // https://github.com/getsentry/sentry-webpack-plugin#options
+	withSentryConfig(
+		nextConfig,
+		{
+			// For all available options, see:
+			// https://github.com/getsentry/sentry-webpack-plugin#options
 
-      // Suppresses source map uploading logs during build
-      silent: true,
-      org: "self-z1o",
-      project: "javascript-nextjs",
-    },
-    {
-      // For all available options, see:
-      // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+			// Suppresses source map uploading logs during build
+			silent: true,
+			org: "self-z1o",
+			project: "javascript-nextjs",
+		},
+		{
+			// For all available options, see:
+			// https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 
-      // Upload a larger set of source maps for prettier stack traces (increases build time)
-      widenClientFileUpload: true,
+			// Upload a larger set of source maps for prettier stack traces (increases build time)
+			widenClientFileUpload: true,
 
-      // Transpiles SDK to be compatible with IE11 (increases bundle size)
-      transpileClientSDK: true,
+			// Transpiles SDK to be compatible with IE11 (increases bundle size)
+			transpileClientSDK: true,
 
-      // Uncomment to route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
-      // This can increase your server load as well as your hosting bill.
-      // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
-      // side errors will fail.
-      // tunnelRoute: "/monitoring",
+			// Uncomment to route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+			// This can increase your server load as well as your hosting bill.
+			// Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+			// side errors will fail.
+			// tunnelRoute: "/monitoring",
 
-      // Hides source maps from generated client bundles
-      hideSourceMaps: true,
+			// Hides source maps from generated client bundles
+			hideSourceMaps: true,
 
-      // Automatically tree-shake Sentry logger statements to reduce bundle size
-      disableLogger: true,
+			// Automatically tree-shake Sentry logger statements to reduce bundle size
+			disableLogger: true,
 
-      // Enables automatic instrumentation of Vercel Cron Monitors.
-      // See the following for more information:
-      // https://docs.sentry.io/product/crons/
-      // https://vercel.com/docs/cron-jobs
-      automaticVercelMonitors: true,
-    }
-  )
-);
+			// Enables automatic instrumentation of Vercel Cron Monitors.
+			// See the following for more information:
+			// https://docs.sentry.io/product/crons/
+			// https://vercel.com/docs/cron-jobs
+			automaticVercelMonitors: true,
+		},
+	),
+)
 
-export default config;
+export default config

--- a/src/app/weather/action.ts
+++ b/src/app/weather/action.ts
@@ -3,11 +3,12 @@
 import errorHandler from "@/utils/errorHandler"
 import { WeatherAPIResponse } from "./types"
 import { getWeatherApiEndpoint } from "./utils/getWeatherApiEndpoint"
-import { getStationInfo } from "./utils/getStationInfo"
+import { getCityInfo } from "./utils/getStationInfo"
+import { UNSPLASH_API_BASE_URL } from "./constant"
 
 export async function getCurrentWeather(cityName: string[]): Promise<WeatherAPIResponse<"CURRENT_WEATHER">> {
 	try {
-		const availableStations = cityName.map((city) => getStationInfo(city))
+		const availableStations = cityName.map((city) => getCityInfo(city, "stationName"))
 		const endpoint = getWeatherApiEndpoint("CURRENT_WEATHER")
 		const response = await fetch(
 			`${endpoint}?StationName=${availableStations.join(",")}&Authorization=${process.env.WEATHER_API_KEY}`,
@@ -22,6 +23,30 @@ export async function getCurrentWeather(cityName: string[]): Promise<WeatherAPIR
 
 		return data
 	} catch (error: any) {
+		throw error
+	}
+}
+
+export async function getCityImage(city: string) {
+	try {
+		const englishName = getCityInfo(city, "englishName")
+		const response = await fetch(`${UNSPLASH_API_BASE_URL}?query=${englishName}`, {
+			headers: {
+				Authorization: `Client-ID ${process.env.UNSPLASH_ACCESS_KEY}`,
+			},
+		})
+		if (!response.ok) {
+			errorHandler("RANDOM_CITY_PHOTO", response.status)
+		}
+		const data = await response.json()
+		const requiredData = {
+			url: data.urls.raw,
+			id: data.id,
+			blurHash: data.blur_hash,
+			alternativeSlugs: data.alternative_slugs,
+		}
+		return requiredData
+	} catch (error) {
 		throw error
 	}
 }

--- a/src/app/weather/components/server/CurrentWeather.tsx
+++ b/src/app/weather/components/server/CurrentWeather.tsx
@@ -7,6 +7,7 @@ import { CurrentWeatherTime, WeatherImage } from "../client"
 
 const Container = styled("div")({
 	flex: 3,
+	zIndex: 1,
 	"h1, h2,h3": {
 		color: "white",
 		margin: 0,

--- a/src/app/weather/components/server/ThirtySixHoursWeather.tsx
+++ b/src/app/weather/components/server/ThirtySixHoursWeather.tsx
@@ -13,6 +13,7 @@ const Container = styled("div")({
 	display: "flex",
 	flexDirection: "column",
 	alignItems: "flex-end",
+	zIndex: 1,
 	h5: {
 		color: "white",
 		textShadow: "2px 2px 4px rgba(0, 0, 0, 0.5)",

--- a/src/app/weather/constant.ts
+++ b/src/app/weather/constant.ts
@@ -1,6 +1,7 @@
 import { WeatherCodeType, WeatherDetailType } from "./types"
 
 export const WEATHER_API_BASE_URL: string = "https://opendata.cwa.gov.tw/api/v1/rest/datastore"
+export const UNSPLASH_API_BASE_URL: string = "https://api.unsplash.com/photos/random"
 
 export const WEATHER_CODE: WeatherCodeType = {
 	THUNDER: [15, 16, 17, 18, 21, 22, 33, 34, 35, 36, 41],

--- a/src/app/weather/data/CityCountyData.ts
+++ b/src/app/weather/data/CityCountyData.ts
@@ -1,94 +1,113 @@
-type CityCounty = {
+export type CityCounty = {
 	cityName: string
 	stationName: string
+	englishName: string
 }
 
 export const CityCountyData: CityCounty[] = [
 	{
 		cityName: "臺北市",
 		stationName: "臺北",
+		englishName: "Taipei",
 	},
 	{
 		cityName: "新北市",
 		stationName: "新北",
+		englishName: "NewTaipei",
 	},
 	{
 		cityName: "宜蘭縣",
 		stationName: "宜蘭",
+		englishName: "Yilan",
 	},
 	{
 		cityName: "基隆市",
 		stationName: "基隆",
+		englishName: "Keelung",
 	},
 	{
 		cityName: "桃園市",
 		stationName: "新屋",
+		englishName: "Taoyuan",
 	},
 	{
 		cityName: "新竹市",
 		stationName: "新竹",
+		englishName: "Hsinchu",
 	},
 	{
 		cityName: "新竹縣",
 		stationName: "新竹",
+		englishName: "Hsinchu",
 	},
-
 	{
 		cityName: "臺中市",
 		stationName: "臺中",
+		englishName: "Taichung",
 	},
 	{
 		cityName: "彰化縣",
 		stationName: "田中",
+		englishName: "Changhua",
 	},
-	// no data
 	{
 		cityName: "雲林縣",
 		stationName: "古坑",
+		englishName: "Yunlin",
 	},
-
 	{
 		cityName: "嘉義市",
 		stationName: "嘉義",
+		englishName: "Chiayi",
 	},
 	{
 		cityName: "嘉義縣",
 		stationName: "阿里山",
+		englishName: "Chiayi",
 	},
 	{
 		cityName: "南投縣",
 		stationName: "日月潭",
+		englishName: "Nantou",
 	},
 	{
 		cityName: "臺南市",
 		stationName: "臺南",
+		englishName: "Tainan",
 	},
 	{
 		cityName: "高雄市",
 		stationName: "高雄",
+		englishName: "Kaohsiung",
 	},
 	{
 		cityName: "屏東縣",
 		stationName: "恆春",
+		englishName: "Pingtung",
 	},
 	{
 		cityName: "花蓮縣",
 		stationName: "花蓮",
+		englishName: "Hualien",
 	},
 	{
 		cityName: "臺東縣",
 		stationName: "臺東",
+		englishName: "Taitung",
 	},
 	{
 		cityName: "連江縣",
 		stationName: "馬祖",
+		englishName: "Lienchiang",
 	},
 	{
 		cityName: "澎湖縣",
 		stationName: "澎湖",
+		englishName: "Penghu",
 	},
 	{
 		cityName: "金門縣",
 		stationName: "金門",
+		englishName: "Kinmen",
 	},
 ]

--- a/src/app/weather/page.tsx
+++ b/src/app/weather/page.tsx
@@ -2,6 +2,8 @@ import { Suspense } from "react"
 import { styled } from "@pigment-css/react"
 import { BottomSection } from "./components/client"
 import { CurrentWeather, ThirtySixHoursWeather } from "./components/server"
+import Image from "next/image"
+import { getCityImage } from "./action"
 
 const TopSection = styled("div")({
 	display: "flex",
@@ -9,17 +11,22 @@ const TopSection = styled("div")({
 	justifyContent: "space-between",
 	padding: "60px 80px",
 	height: "60vh",
-	backgroundImage:
-		"linear-gradient(rgba(0,0,0,0.1), rgba(0,0,0,0.3)), url('https://images.unsplash.com/photo-1561105111-d592363f0472?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1OTIxODF8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MTQwNTc1MTd8&ixlib=rb-4.0.3&q=80&w=2000')",
-	backgroundSize: "cover",
-	backgroundPosition: "center",
+	position: "relative",
 	backgroundColor: "#252746",
 	"@media (max-width: 1440px)": {
-		// flexDirection: "column",
-		// height: "70vh",
 		gap: "20px",
 		padding: "30px 40px",
 	},
+})
+
+const ImageMask = styled("div")({
+	position: "absolute",
+	width: "100%",
+	height: "100%",
+	zIndex: 0,
+	top: 0,
+	left: 0,
+	backgroundColor: "rgba(0, 0, 0, 0.3)",
 })
 
 export default async function WeatherPage({
@@ -27,9 +34,13 @@ export default async function WeatherPage({
 }: {
 	searchParams: { [key: string]: string }
 }) {
+	const cityImageData = await getCityImage(city)
+
 	return (
 		<>
 			<TopSection>
+				<Image src={cityImageData.url} alt="city image" fill={true} objectFit="cover" objectPosition="center" />
+				<ImageMask />
 				<Suspense fallback={<div>Loading...</div>}>
 					<CurrentWeather city={city} />
 				</Suspense>

--- a/src/app/weather/types.ts
+++ b/src/app/weather/types.ts
@@ -4,6 +4,10 @@ export enum WeatherAPI {
 	SUNRISE_SUNSET_TIME = "A-B0062-001",
 }
 
+export enum UnsplashAPI {
+	RANDOM_CITY_PHOTO,
+}
+
 export type CityResponseType = Record<"cities", string[]>
 
 export enum Weather {
@@ -25,6 +29,7 @@ export type WeatherIconType = {
 }
 
 export type WeatherApiAlias = keyof typeof WeatherAPI
+export type UnsplashAPIAlias = keyof typeof UnsplashAPI
 type WeatherApiRecordTypes = {
 	[k in WeatherApiAlias]: k extends "CURRENT_WEATHER"
 		? CurrentWeatherRecords

--- a/src/app/weather/utils/getStationInfo.ts
+++ b/src/app/weather/utils/getStationInfo.ts
@@ -1,8 +1,8 @@
-import { CityCountyData } from "../data/CityCountyData"
+import { CityCounty, CityCountyData } from "../data/CityCountyData"
 
-export function getStationInfo(city: string) {
+export function getCityInfo(city: string, key: keyof CityCounty) {
 	for (const data of CityCountyData) {
-		if (data.cityName === city) return data.stationName
+		if (data.cityName === city) return data[key]
 	}
 	throw new Error(`City ${city} is not available.`)
 }

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,6 +1,6 @@
-import { WeatherApiAlias } from "@/app/weather/types"
+import { UnsplashAPIAlias, WeatherApiAlias } from "@/app/weather/types"
 
-type apiAlias = WeatherApiAlias
+type apiAlias = WeatherApiAlias | UnsplashAPIAlias
 
 export default function errorHandler(apiAlias: apiAlias, status: Response["status"]) {
 	switch (status) {


### PR DESCRIPTION
## Proposed Change

use next/image as background in `TopSection` and get city image from **unsplash** based on city

## Solution

- [8720e45](https://github.com/Maki0419-git/miyu-website/pull/20/commits/8720e453fdae67ff3220268f21e0c1ed96b0f65c): add action to fetch city image and it can be share in RSC ans RCC
- [65ae265](https://github.com/Maki0419-git/miyu-website/pull/20/commits/65ae2656eee335938fd99f56c142ec6d5156a509): use `next/image` 


## Related Info
📅 日期 : 

🗒️ clickup :

🧑‍🎨 figma:

🐾 issue: 

📓 others:

## I am abided to...：
- [x] 大家所訂定的 [Git comment 格式](https://app.clickup.com/5719919/docs/5ehvf-1720)
- [x] 每個 commit 不超過 200 行變動
- [x] 每個  PR 不超過 500 行變動
