### PR TITLE
fix(weather): decide is day or night more correctly

### DIFF
--- a/src/app/weather/components/client/WeatherImage.tsx
+++ b/src/app/weather/components/client/WeatherImage.tsx
@@ -8,6 +8,8 @@ import errorHandler from "@/utils/errorHandler"
 
 dayjs.extend(timezone)
 
+const generateDayjsInTaipei = (date: string) => dayjs(date).tz("Asia/Taipei", true)
+
 async function getSunriseSunsetTime(city: string, date: string): Promise<WeatherAPIResponse<"SUNRISE_SUNSET_TIME">> {
 	try {
 		const endpoint = getWeatherApiEndpoint("SUNRISE_SUNSET_TIME")
@@ -34,11 +36,11 @@ export async function WeatherImage({
 	city: string
 	targetTime: string
 }) {
-	const day = dayjs(targetTime).tz("Asia/Taipei")
-	const date = day.format("YYYY-MM-DD")
+	const dayWithoutTimezone = targetTime.replace(/\+\d{2}:\d{2}$/, "")
+	const date = generateDayjsInTaipei(dayWithoutTimezone).format("YYYY-MM-DD")
 	const data = await getSunriseSunsetTime(city, date)
 	const sunriseSunsetTime = data.records.locations.location[0].time[0]
-	const isDayOrNight = getIsDayOrNight(dayjs(targetTime), sunriseSunsetTime)
+	const isDayOrNight = getIsDayOrNight(dayWithoutTimezone, generateDayjsInTaipei, sunriseSunsetTime)
 	const weatherIcon = WEATHER_ICON[isDayOrNight][weather]
 
 	return weatherIcon

--- a/src/app/weather/utils/getIsDayOrNight.ts
+++ b/src/app/weather/utils/getIsDayOrNight.ts
@@ -1,11 +1,17 @@
-import dayjs, { Dayjs } from "dayjs"
+import { Dayjs } from "dayjs"
 import { SunriseSunsetTime } from "../types"
 
-export function getIsDayOrNight(targetTime: Dayjs = dayjs(), sunriseSunsetTime: SunriseSunsetTime): "day" | "night" {
+export function getIsDayOrNight(
+	targetTime: string,
+	generateDayjsInTaipei: (time: string) => Dayjs,
+	sunriseSunsetTime: SunriseSunsetTime,
+): "day" | "night" {
 	const { Date: date, SunRiseTime: sunriseTime, SunSetTime: sunsetTime } = sunriseSunsetTime
-	const targetTimeInMilliseconds = targetTime.valueOf()
-	const sunriseTimeInMilliseconds = dayjs(`${date} ${sunriseTime}`).valueOf()
-	const sunsetTimeInMilliseconds = dayjs(`${date} ${sunsetTime}`).valueOf()
+
+	const targetTimeInMilliseconds = generateDayjsInTaipei(targetTime).valueOf()
+	const sunriseTimeInMilliseconds = generateDayjsInTaipei(`${date} ${sunriseTime}`).valueOf()
+	const sunsetTimeInMilliseconds = generateDayjsInTaipei(`${date} ${sunsetTime}`).valueOf()
+
 	return targetTimeInMilliseconds >= sunriseTimeInMilliseconds && targetTimeInMilliseconds <= sunsetTimeInMilliseconds
 		? "day"
 		: "night"


### PR DESCRIPTION
## Proposed Change

convert the `day` generate by dayjs() using timezone in Taipei , or it will be using the timezone where server is, and return the unexpected result.

## Solution

- [0164951](https://github.com/Maki0419-git/miyu-website/pull/22/commits/016495131bfc58900f2ee84a610833df0ae20c3b): 
   - use regex to make sure all the `targetTime` is without timezone
   - use `generateDayjsInTaipei` to make sure the day is in TP timezone


## Related Info
📅 日期 : 

🗒️ clickup :

🧑‍🎨 figma:

🐾 issue: 

📓 others:

## I am abided to...：
- [x] 大家所訂定的 [Git comment 格式](https://app.clickup.com/5719919/docs/5ehvf-1720)
- [x] 每個 commit 不超過 200 行變動
- [x] 每個  PR 不超過 500 行變動
